### PR TITLE
Remove hiredis parser and upgrade redis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "circuit-breaker": "git://github.com/Tinder/circuit-breaker",
-    "hiredis": "^0.4.1",
-    "redis": "2.4.2"
+    "redis": "2.6.2"
   },
   "devDependencies": {
     "jasmine": "^2.4.1",


### PR DESCRIPTION
`node-redis` 2.6.2 drops *official* support for redis < v2.6, however they don't say that it will not work; just that they can no longer test against it.

2.6.2 comes with significant performance increases, largely by dropping `hiredis` in favor of their js parser. It should still be possible to include `hiredis` if someone wants it for some reason.

All tests still pass.